### PR TITLE
fix: --web not embedding all files

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -15,7 +15,7 @@ import (
 //go:embed html/*
 var htmlFiles embed.FS
 
-//go:embed dist/*
+//go:embed all:dist
 var distFiles embed.FS
 
 var Template = `

--- a/app/file-server.go
+++ b/app/file-server.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"log"
 	"net/http"
 	"os"
 	"path"
@@ -44,6 +45,8 @@ func FileServerWith404(root http.FileSystem, handler404 FSHandler404) http.Handl
 		f, err := root.Open(upath)
 		if err != nil {
 			if os.IsNotExist(err) {
+				log.Printf("Embedded asset not found: %s", upath)
+
 				// call handler
 				if handler404 != nil {
 					doDefault := handler404(w, r)
@@ -51,6 +54,8 @@ func FileServerWith404(root http.FileSystem, handler404 FSHandler404) http.Handl
 						return
 					}
 				}
+			} else {
+				log.Printf("error opening asset %s: %v", upath, err)
 			}
 		}
 


### PR DESCRIPTION
Built app wasn't working because some of the files in `dist` have names starting with `_`. Our `embed` statement was ignoring these files. Fixed it by using `all:` prefix when embedding

> If a pattern begins with the prefix ‘all:’, then the rule for walking directories is changed to include those files beginning with ‘.’ or ‘_’. For example, ‘all:image’ embeds both ‘image/.tempfile’ and ‘image/dir/.tempfile’.
>
> [Go docs on embed](https://pkg.go.dev/embed)

