### PR TITLE
switch to english chapter names for the quran

### DIFF
--- a/web/app/routes/_app.quran.tsx
+++ b/web/app/routes/_app.quran.tsx
@@ -27,10 +27,10 @@ export default function Quran() {
   const sidebarItems: SidebarItem[] =
     chapters?.map((chapter) => ({
       key: chapter.number,
-      text: chapter.name,
+      text: chapter.english,
       path: `/quran/${chapter.number}`,
       number: chapter.number,
-      searchableText: [chapter.name],
+      searchableText: [chapter.english],
     })) || [];
 
   return (


### PR DESCRIPTION
Switching to english for chapter names as this is what the lite version was doing. It would be nice to display both english and arabic but for now I think just purely for understanding I'll go with english.