### PR TITLE
feat: add extra info to /names

### DIFF
--- a/web/app/routes/_app.names.tsx
+++ b/web/app/routes/_app.names.tsx
@@ -22,10 +22,11 @@ export default function Names() {
 
   const sidebarItems: SidebarItem[] = names?.map(name => ({
     key: name.number,
-    text: name.meaning,
+    text: name.english,
     path: `/names/${name.number}`,
     number: name.number,
-    searchableText: [name.meaning, name.english]
+    searchableText: [name.meaning, name.english],
+    extra: name.meaning
   })) || [];
 
   return (


### PR DESCRIPTION
As done previously with /quran sidebar, this PR adds extra information to /names

<img width="553" alt="image" src="https://github.com/user-attachments/assets/97dc2339-f723-45a7-b54a-9b3ae6b6b6e0" />
