### PR TITLE
Fix alignment of arabic text

### DIFF
--- a/web/app/routes/_app.quran.$chapterNumber._index.tsx
+++ b/web/app/routes/_app.quran.$chapterNumber._index.tsx
@@ -74,7 +74,7 @@ export default function QuranChapter(props: Route.ComponentProps) {
       {mode === 'arabic' && (
         <div
           dir='rtl'
-          className='flex flex-grow flex-wrap font-arabic text-right text-xl sm:text-2xl md:text-3xl leading-loose'
+          className='flex flex-grow flex-wrap font-arabic text-right text-xl sm:text-2xl md:text-3xl leading-loose content-start'
         >
           {data.verses.map((verse) => (
             <Fragment key={verse.number}>


### PR DESCRIPTION
The recent change of wrapping words inside `span` caused the alignment of arabic text to be broken on smaller devices

<img width="629" alt="image" src="https://github.com/user-attachments/assets/1182efce-9d01-4ab5-8e71-7363f1123dd9" />

This PR fixes it

<img width="627" alt="image" src="https://github.com/user-attachments/assets/f7ea7ac2-c6bd-4875-90ac-f73b60cbb0b5" />
