### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Find the latest [release](https://github.com/asim/reminder/releases/latest)
 Or Go install
 
 ```
-go get github.com.com/asim/reminder@latest
+go install github.com/asim/reminder@latest
 ```
 
 ## Usage


### PR DESCRIPTION
I think  [`install`](https://go.dev/doc/go-get-install-deprecation) should be used instead of `get`. Also removed the double .com in the URL